### PR TITLE
Give the failing pcretest a bit more memory

### DIFF
--- a/3rdparty/pcre-8.10/RunTest
+++ b/3rdparty/pcre-8.10/RunTest
@@ -150,7 +150,7 @@ fi
 
 if [ $do2 = yes ] ; then
   echo "Test 2: API, errors, internals, and non-Perl stuff"
-  $valgrind ./pcretest -q $testdata/testinput2 testtry
+  $valgrind ./pcretest -S 16 -q $testdata/testinput2 testtry
   if [ $? = 0 ] ; then
     $cf $testdata/testoutput2 testtry
     if [ $? != 0 ] ; then exit 1; fi


### PR DESCRIPTION
It seems the default size is a bit too small when the code is compiled with
clang to run the test successfully. Just increasing the limit of the stack
is enough for the test to succeeds so do that since the test itself claims
it requires a relatively large stack.