### PR TITLE
Drop std::auto_ptr use for C++17 compatibility

### DIFF
--- a/hooklib/variabledumping.cpp
+++ b/hooklib/variabledumping.cpp
@@ -164,6 +164,7 @@ VariableSnapshot::VariableSnapshot()
 
 VariableSnapshot::~VariableSnapshot()
 {
+    delete m_variables;
 }
 
 

--- a/hooklib/variabledumping.h
+++ b/hooklib/variabledumping.h
@@ -238,7 +238,15 @@ public:
     TRACELIB_EXPORT AbstractVariable *&operator[]( size_t idx );
 
 private:
-    std::auto_ptr<std::vector<AbstractVariable *> > m_variables;
+#if __cplusplus >= 201103L
+    VariableSnapshot( const VariableSnapshot & ) = delete;
+    VariableSnapshot& operator=( const VariableSnapshot& ) = delete;
+#else
+    VariableSnapshot( const VariableSnapshot & );
+    VariableSnapshot& operator=( const VariableSnapshot& );
+#endif
+
+    std::vector<AbstractVariable *> *m_variables;
 };
 
 TRACELIB_NAMESPACE_END


### PR DESCRIPTION
std::auto_ptr is deprecated since C++11 and removed in C++17 which
makes using this header problematic in modern projects. Replace the
type with manual memory management so memory management for these
objects is still kept inside the trace library.

To account for the special assignment/copy semantics of std::auto_ptr,
this change also explicitely disables copying of VariableSnapshot.
Doing so is at least unproblematic for all public macros since the
tracelib implementation passes VariableSnapshots around as pointers
to heap object, i.e. copying is not required.